### PR TITLE
Add unary operation specializations

### DIFF
--- a/src/qutip_jax/__init__.py
+++ b/src/qutip_jax/__init__.py
@@ -24,3 +24,4 @@ qutip.data.create.add_creators(
 
 
 from .binops import *
+from .unary import *

--- a/src/qutip_jax/__init__.py
+++ b/src/qutip_jax/__init__.py
@@ -21,3 +21,6 @@ qutip.data.create.add_creators(
         (is_jax_array, JaxArray, 85),
     ]
 )
+
+
+from .binops import *

--- a/src/qutip_jax/binops.py
+++ b/src/qutip_jax/binops.py
@@ -1,0 +1,91 @@
+import qutip
+from .jaxarray import JaxArray
+
+__all__ = [
+    "add_jaxarray",
+    "sub_jaxarray",
+    "matmul_jaxarray",
+    "multiply_jaxarray"
+]
+
+
+def _check_same_shape(left, right):
+    if left.shape != right.shape:
+        raise ValueError(
+            f"""Incompatible shapes for addition of two matrices:
+                         left={left.shape} and right={right.shape}"""
+        )
+
+
+def _check_matmul_shape(left, right, out):
+    if left.shape[1] != right.shape[0]:
+        raise ValueError(
+            "incompatible matrix shapes " + str(left.shape)
+            + " and " + str(right.shape)
+        )
+    if (
+        out is not None
+        and out.shape[0] != left.shape[0]
+        and out.shape[1] != right.shape[1]
+    ):
+        raise ValueError(
+            "incompatible output shape, got "
+            + str(out.shape)
+            + " but needed "
+            + str((left.shape[0], right.shape[1]))
+        )
+
+
+def add_jaxarray(left, right, scale=1):
+    _check_same_shape(left, right)
+
+    if scale == 1 and isinstance(scale, int):
+        out = JaxArray._fast_constructor(
+            left._jxa + right._jxa, shape=left.shape
+        )
+    else:
+        out = JaxArray._fast_constructor(
+            left._jxa + scale * right._jxa, shape=left.shape
+        )
+    return out
+
+
+def sub_jaxarray(left, right):
+    return add_jaxarray(left, right, -1)
+
+
+def matmul_jaxarray(left, right, scale=1, out=None):
+    _check_matmul_shape(left, right, out)
+    shape = (left.shape[0], right.shape[1])
+
+    result = left._jxa @ right._jxa
+
+    if scale != 1 or not isinstance(scale, int):
+        result *= scale
+
+    if out is None:
+        return JaxArray._fast_constructor(result, shape=shape)
+    else:
+        out._jxa = result + out._jxa
+
+
+def multiply_jaxarray(left, right):
+    _check_same_shape(left, right)
+    return JaxArray._fast_constructor(left._jxa * right._jxa, shape=left.shape)
+
+
+qutip.data.matmul.add_specialisations(
+    [(JaxArray, JaxArray, JaxArray, matmul_jaxarray),]
+)
+
+qutip.data.add.add_specialisations(
+    [(JaxArray, JaxArray, JaxArray, add_jaxarray),]
+)
+
+qutip.data.sub.add_specialisations(
+    [(JaxArray, JaxArray, JaxArray, sub_jaxarray),]
+)
+
+qutip.data.multiply.add_specialisations(
+    [(JaxArray, JaxArray, JaxArray, multiply_jaxarray),]
+)

--- a/src/qutip_jax/binops.py
+++ b/src/qutip_jax/binops.py
@@ -4,6 +4,7 @@ from .jaxarray import JaxArray
 __all__ = [
     "add_jaxarray",
     "sub_jaxarray",
+    "mul_jaxarray",
     "matmul_jaxarray",
     "multiply_jaxarray"
 ]
@@ -54,6 +55,10 @@ def sub_jaxarray(left, right):
     return add_jaxarray(left, right, -1)
 
 
+def mul_jaxarray(matrix, value):
+    return JaxArray._fast_constructor(matrix._jxa * value, matrix.shape)
+
+
 def matmul_jaxarray(left, right, scale=1, out=None):
     _check_matmul_shape(left, right, out)
     shape = (left.shape[0], right.shape[1])
@@ -74,16 +79,20 @@ def multiply_jaxarray(left, right):
     return JaxArray._fast_constructor(left._jxa * right._jxa, shape=left.shape)
 
 
-qutip.data.matmul.add_specialisations(
-    [(JaxArray, JaxArray, JaxArray, matmul_jaxarray),]
-)
-
 qutip.data.add.add_specialisations(
     [(JaxArray, JaxArray, JaxArray, add_jaxarray),]
 )
 
 qutip.data.sub.add_specialisations(
     [(JaxArray, JaxArray, JaxArray, sub_jaxarray),]
+)
+
+qutip.data.mul.add_specialisations(
+    [(JaxArray, JaxArray, mul_jaxarray),]
+)
+
+qutip.data.matmul.add_specialisations(
+    [(JaxArray, JaxArray, JaxArray, matmul_jaxarray),]
 )
 
 qutip.data.multiply.add_specialisations(

--- a/src/qutip_jax/jaxarray.py
+++ b/src/qutip_jax/jaxarray.py
@@ -65,6 +65,13 @@ class JaxArray(Data):
     def trace(self):
         return jnp.trace(self._jxa)
 
+    @classmethod
+    def _fast_constructor(cls, array, shape):
+        out = cls.__new__(cls)
+        Data.__init__(out, shape)
+        out._jxa = array
+        return out
+
     def _tree_flatten(self):
         children = (self._jxa,)  # arrays / dynamic values
         aux_data = {"shape": self.shape}  # static values

--- a/src/qutip_jax/unary.py
+++ b/src/qutip_jax/unary.py
@@ -1,0 +1,107 @@
+import qutip
+from .jaxarray import JaxArray
+from .binops import mul_jaxarray
+import jax.scipy.linalg as linalg
+from jax import jit
+
+__all__ = [
+    "neg_jaxarray",
+    "adjoint_jaxarray",
+    "transpose_jaxarray",
+    "conj_jaxarray",
+    "inv_jaxarray",
+    "expm_jaxarray",
+    "project_jaxarray",
+]
+
+
+def _check_square_shape(matrix):
+    if matrix.shape[0] != matrix.shape[1]:
+        raise ValueError(
+            f"Can only be performed for square matrix. "
+            f"This matrix has shape={matrix.shape}"
+        )
+
+
+def neg_jaxarray(matrix):
+    return mul_jaxarray(matrix, -1)
+
+
+@jit
+def adjoint_jaxarray(matrix):
+    return JaxArray(matrix._jxa.T.conj())
+
+
+def transpose_jaxarray(matrix):
+    return JaxArray(matrix._jxa.T)
+
+
+def conj_jaxarray(matrix):
+    return JaxArray._fast_constructor(matrix._jxa.conj(), matrix.shape)
+
+
+def expm_jaxarray(matrix):
+    _check_square_shape(matrix)
+    return JaxArray._fast_constructor(linalg.expm(matrix._jxa), matrix.shape)
+
+
+def inv_jaxarray(matrix):
+    _check_square_shape(matrix)
+    return JaxArray._fast_constructor(linalg.inv(matrix._jxa), matrix.shape)
+
+
+@jit
+def _project_ket(array):
+    return array @ array.T.conj()
+
+
+@jit
+def _project_bra(array):
+    return array.T.conj() @ array
+
+
+def project_jaxarray(state):
+    if state.shape[1] == 1:
+        # Is ket
+        out = _project_ket(state._jxa)
+    elif state.shape[0] == 1:
+        # Is bra
+        out = _project_bra(state._jxa)
+    else:
+        raise ValueError("state must be a ket or a bra.")
+    return JaxArray(out)
+
+
+qutip.data.neg.add_specialisations(
+    [(JaxArray, JaxArray, neg_jaxarray),]
+)
+
+
+qutip.data.adjoint.add_specialisations(
+    [(JaxArray, JaxArray, adjoint_jaxarray),]
+)
+
+
+qutip.data.transpose.add_specialisations(
+    [(JaxArray, JaxArray, transpose_jaxarray),]
+)
+
+
+qutip.data.conj.add_specialisations(
+    [(JaxArray, JaxArray, conj_jaxarray),]
+)
+
+
+qutip.data.expm.add_specialisations(
+    [(JaxArray, JaxArray, expm_jaxarray),]
+)
+
+
+qutip.data.inv.add_specialisations(
+    [(JaxArray, inv_jaxarray),]
+)
+
+
+qutip.data.project.add_specialisations(
+    [(JaxArray, JaxArray, project_jaxarray),]
+)

--- a/src/qutip_jax/unary.py
+++ b/src/qutip_jax/unary.py
@@ -24,28 +24,34 @@ def _check_square_shape(matrix):
 
 
 def neg_jaxarray(matrix):
+    """Unary element-wise negation of a matrix."""
     return mul_jaxarray(matrix, -1)
 
 
 @jit
 def adjoint_jaxarray(matrix):
+    """Hermitian adjoint (matrix conjugate transpose)."""
     return JaxArray(matrix._jxa.T.conj())
 
 
 def transpose_jaxarray(matrix):
+    """Transpose of a matrix."""
     return JaxArray(matrix._jxa.T)
 
 
 def conj_jaxarray(matrix):
+    """Element-wise conjugation of a matrix."""
     return JaxArray._fast_constructor(matrix._jxa.conj(), matrix.shape)
 
 
 def expm_jaxarray(matrix):
+    """Matrix exponential `e**A` for a matrix `A`."""
     _check_square_shape(matrix)
     return JaxArray._fast_constructor(linalg.expm(matrix._jxa), matrix.shape)
 
 
 def inv_jaxarray(matrix):
+    """Matrix inverse `A**-1` for a matrix `A`."""
     _check_square_shape(matrix)
     return JaxArray._fast_constructor(linalg.inv(matrix._jxa), matrix.shape)
 
@@ -61,6 +67,10 @@ def _project_bra(array):
 
 
 def project_jaxarray(state):
+    """
+    Get the projector of a state with itself.  Mathematically, if passed an
+    object `|a>` or `<a|`, then return the matrix `|a><a|`.
+    """
     if state.shape[1] == 1:
         # Is ket
         out = _project_ket(state._jxa)

--- a/src/qutip_jax/unary.py
+++ b/src/qutip_jax/unary.py
@@ -108,7 +108,7 @@ qutip.data.expm.add_specialisations(
 
 
 qutip.data.inv.add_specialisations(
-    [(JaxArray, inv_jaxarray),]
+    [(JaxArray, JaxArray, inv_jaxarray),]
 )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+from jax import random
+import qutip_jax
+
+key = random.PRNGKey(1234)
+
+def _random_cplx(shape):
+    return qutip_jax.JaxArray(
+        random.normal(key, shape) + 1j*random.normal(key, shape)
+    )

--- a/tests/test_binops.py
+++ b/tests/test_binops.py
@@ -33,6 +33,15 @@ class TestSub(testing.TestSub):
         )
     ]
 
+class TestMul(testing.TestMul):
+    specialisations = [
+        pytest.param(
+            qutip_jax.mul_jaxarray,
+            qutip_jax.JaxArray,
+            qutip_jax.JaxArray
+        )
+    ]
+
 class TestMatmul(testing.TestMatmul):
     specialisations = [
         pytest.param(

--- a/tests/test_binops.py
+++ b/tests/test_binops.py
@@ -1,0 +1,54 @@
+import qutip.tests.core.data.test_mathematics as testing
+import qutip_jax
+import pytest
+
+from . import conftest
+
+
+testing._ALL_CASES = {
+    qutip_jax.JaxArray: lambda shape: [lambda: conftest._random_cplx(shape)]
+}
+testing._RANDOM = {
+    qutip_jax.JaxArray: lambda shape: [lambda: conftest._random_cplx(shape)]
+}
+
+
+class TestAdd(testing.TestAdd):
+    specialisations = [
+        pytest.param(
+            qutip_jax.add_jaxarray,
+            qutip_jax.JaxArray,
+            qutip_jax.JaxArray,
+            qutip_jax.JaxArray
+        )
+    ]
+
+class TestSub(testing.TestSub):
+    specialisations = [
+        pytest.param(
+            qutip_jax.sub_jaxarray,
+            qutip_jax.JaxArray,
+            qutip_jax.JaxArray,
+            qutip_jax.JaxArray
+        )
+    ]
+
+class TestMatmul(testing.TestMatmul):
+    specialisations = [
+        pytest.param(
+            qutip_jax.matmul_jaxarray,
+            qutip_jax.JaxArray,
+            qutip_jax.JaxArray,
+            qutip_jax.JaxArray
+        )
+    ]
+
+class TestMultiply(testing.TestMultiply):
+    specialisations = [
+        pytest.param(
+            qutip_jax.multiply_jaxarray,
+            qutip_jax.JaxArray,
+            qutip_jax.JaxArray,
+            qutip_jax.JaxArray
+        )
+    ]

--- a/tests/test_unary.py
+++ b/tests/test_unary.py
@@ -23,20 +23,22 @@ class TestNeg(testing.TestNeg):
 
 class TestAdjoint(testing.TestAdjoint):
     specialisations = [
-        pytest.param(qutip_jax.adjoint_jaxarray, JaxArray, JaxArray)
+        pytest.param(qutip_jax.adjoint_jaxarray, JaxArray, JaxArray),
+        pytest.param(lambda mat: mat.adjoint(), JaxArray, JaxArray)
     ]
 
 
 class TestConj(testing.TestConj):
     specialisations = [
-        pytest.param(qutip_jax.conj_jaxarray, JaxArray, JaxArray)
+        pytest.param(qutip_jax.conj_jaxarray, JaxArray, JaxArray),
+        pytest.param(lambda mat: mat.conj(), JaxArray, JaxArray)
     ]
 
 
 class TestTranspose(testing.TestTranspose):
     specialisations = [
-        pytest.param(
-            qutip_jax.transpose_jaxarray, JaxArray, JaxArray)
+        pytest.param(qutip_jax.transpose_jaxarray, JaxArray, JaxArray),
+        pytest.param(lambda mat: mat.transpose(), JaxArray, JaxArray)
     ]
 
 

--- a/tests/test_unary.py
+++ b/tests/test_unary.py
@@ -1,0 +1,70 @@
+import qutip.tests.core.data.test_mathematics as testing
+import qutip_jax
+from qutip_jax import JaxArray
+import pytest
+from qutip.core import data
+
+from . import conftest
+
+
+testing._ALL_CASES = {
+    qutip_jax.JaxArray: lambda shape: [lambda: conftest._random_cplx(shape)]
+}
+testing._RANDOM = {
+    qutip_jax.JaxArray: lambda shape: [lambda: conftest._random_cplx(shape)]
+}
+
+
+class TestNeg(testing.TestNeg):
+    specialisations = [
+        pytest.param(qutip_jax.neg_jaxarray, JaxArray, JaxArray),
+    ]
+
+
+class TestAdjoint(testing.TestAdjoint):
+    specialisations = [
+        pytest.param(qutip_jax.adjoint_jaxarray, JaxArray, JaxArray)
+    ]
+
+
+class TestConj(testing.TestConj):
+    specialisations = [
+        pytest.param(qutip_jax.conj_jaxarray, JaxArray, JaxArray)
+    ]
+
+
+class TestTranspose(testing.TestTranspose):
+    specialisations = [
+        pytest.param(
+            qutip_jax.transpose_jaxarray, JaxArray, JaxArray)
+    ]
+
+
+class TestExpm(testing.TestExpm):
+    specialisations = [
+        pytest.param(
+            qutip_jax.expm_jaxarray, JaxArray, JaxArray)
+    ]
+
+
+def _inv_jax(matrix):
+    # Add a diagonal so `matrix` is not singular
+    return qutip_jax.inv_jaxarray(
+        data.add(
+            matrix,
+            data.diag([1.1]*matrix.shape[0], shape=matrix.shape, dtype='JaxArray')
+        )
+    )
+
+class TestInv(testing.TestInv):
+    specialisations = [
+        pytest.param(
+            _inv_jax, JaxArray, JaxArray)
+    ]
+
+
+class TestProject(testing.TestProject):
+    specialisations = [
+        pytest.param(
+            qutip_jax.project_jaxarray, JaxArray, JaxArray)
+    ]


### PR DESCRIPTION
Add specialized dispatch functions for `neg`, `conj`, `adjoint`, `transpose`, `expm` `inv` and `project`.
It's include all `JaxArray -> JaxArray` functions except `logm`, for which jax does not have and implementation yet.

Functions composed multiple jax operation are jitted, but I did not benchmark them to see if it's useful.
Tests for the methods  `conj`, `adjoint`, `transpose` are included.

This PR comes after #2, it reuse `conftest.py`.



