### PR TITLE
Add permutation specialisations

### DIFF
--- a/src/qutip_jax/__init__.py
+++ b/src/qutip_jax/__init__.py
@@ -25,3 +25,4 @@ qutip.data.create.add_creators(
 
 from .binops import *
 from .unary import *
+from .permute import *

--- a/src/qutip_jax/permute.py
+++ b/src/qutip_jax/permute.py
@@ -1,0 +1,61 @@
+import qutip
+from .jaxarray import JaxArray
+from jax import jit
+import numpy as np
+
+
+def indices_jaxarray(matrix, row_perm=None, col_perm=None):
+    if row_perm is None and col_perm is None:
+        return matrix.copy()
+    data = matrix._jxa
+    if row_perm is not None:
+        data = data[np.argsort(row_perm), :]
+    if col_perm is not None:
+        data = data[:, np.argsort(col_perm)]
+    return JaxArray(data)
+
+
+def dimensions_jaxarray(matrix, dimensions, order):
+    dims = np.array(dimensions, dtype=int)
+    order = np.array(order, dtype=int)
+    N = len(dimensions)
+    size = matrix.shape[0]
+    if size == 1:
+        size = matrix.shape[1]
+
+    if np.any(0 >= dims):
+        raise ValueError("invalid dimensions")
+    if np.any(0 > order) or np.any(order >= N):
+        raise ValueError(f"invalid order, {order}")
+    if len(np.unique(order)) != N:
+        raise ValueError("duplicate order element")
+    if len(order) != N:
+        raise ValueError("invalid order: wrong number of elements")
+    if np.prod(dims) != size:
+        raise ValueError("dimensions does not match the shape")
+
+    cumprod = np.ones(N, dtype=int)
+    for i in range(N - 1):
+        cumprod[i+1] = cumprod[i] * dims[order][-i-1]
+    cumprod = cumprod[::-1][np.argsort(order)]
+    idx = np.arange(size)
+    permute = np.zeros(size, dtype=int)
+    for dim, step in zip(dims[::-1], cumprod[::-1]):
+        permute += step * (idx % dim)
+        idx //= dim
+    row_perm, col_perm = None, None
+    if matrix.shape[0] == size:
+        row_perm = permute
+    if matrix.shape[1] == size:
+        col_perm = permute
+    return indices_jaxarray(matrix, row_perm, col_perm)
+
+
+qutip.data.permute.indices.add_specialisations([
+    (JaxArray, JaxArray, indices_jaxarray),
+])
+
+
+qutip.data.permute.dimensions.add_specialisations([
+    (JaxArray, JaxArray, dimensions_jaxarray),
+])

--- a/tests/test_permute.py
+++ b/tests/test_permute.py
@@ -1,0 +1,70 @@
+import qutip
+from qutip_jax import JaxArray
+
+class TestPermute():
+    def test_psi(self):
+        A = qutip.basis(3, 0, dtype="jax")
+        B = qutip.basis(5, 4, dtype="jax")
+        C = qutip.basis(4, 2, dtype="jax")
+        psi = qutip.tensor(A, B, C)
+        psi2 = psi.permute([2, 0, 1])
+        assert psi2 == qutip.tensor(C, A, B)
+        assert isinstance(psi2.data, JaxArray)
+
+        psi_bra = psi.dag()
+        psi2_bra = psi_bra.permute([2, 0, 1])
+        assert psi2_bra == qutip.tensor(C, A, B).dag()
+        assert isinstance(psi2_bra.data, JaxArray)
+
+        for _ in range(3):
+            A = qutip.rand_ket(3, dtype="jax")
+            B = qutip.rand_ket(4, dtype="jax")
+            C = qutip.rand_ket(5, dtype="jax")
+            psi = qutip.tensor(A, B, C)
+            psi2 = psi.permute([1, 0, 2])
+            assert psi2 == qutip.tensor(B, A, C)
+            assert isinstance(psi2.data, JaxArray)
+
+            psi_bra = psi.dag()
+            psi2_bra = psi_bra.permute([1, 0, 2])
+            assert psi2_bra == qutip.tensor(B, A, C).dag()
+            assert isinstance(psi2_bra.data, JaxArray)
+
+    def test_oper(self):
+        A = qutip.fock_dm(3, 0, dtype="jax")
+        B = qutip.fock_dm(5, 4, dtype="jax")
+        C = qutip.fock_dm(4, 2, dtype="jax")
+        rho = qutip.tensor(A, B, C)
+        rho2 = rho.permute([2, 0, 1])
+        assert rho2 == qutip.tensor(C, A, B)
+        assert isinstance(rho2.data, JaxArray)
+
+        for _ in range(3):
+            A = qutip.rand_dm(3, dtype="jax")
+            B = qutip.rand_dm(4, dtype="jax")
+            C = qutip.rand_dm(5, dtype="jax")
+            rho = qutip.tensor(A, B, C)
+            rho2 = rho.permute([1, 0, 2])
+            assert rho2 == qutip.tensor(B, A, C)
+            assert isinstance(rho2.data, JaxArray)
+
+            rho_vec = qutip.operator_to_vector(rho)
+            rho2_vec = rho_vec.permute([[1, 0, 2], [4, 3, 5]])
+            assert rho2_vec == qutip.operator_to_vector(qutip.tensor(B, A, C))
+            assert isinstance(rho2_vec.data, JaxArray)
+
+            rho_vec_bra = qutip.operator_to_vector(rho).dag()
+            rho2_vec_bra = rho_vec_bra.permute([[1, 0, 2], [4, 3, 5]])
+            assert (rho2_vec_bra
+                    == qutip.operator_to_vector(qutip.tensor(B, A, C)).dag())
+            assert isinstance(rho2_vec_bra.data, JaxArray)
+
+    def test_super(self):
+        for _ in range(3):
+            super_dims = [3, 5, 4]
+            U = qutip.rand_unitary(super_dims, dtype="jax")
+            Unew = U.permute([2, 1, 0])
+            S_tens = qutip.to_super(U)
+            S_tens_new = qutip.to_super(Unew)
+            assert S_tens_new == S_tens.permute([[2, 1, 0], [5, 4, 3]])
+            assert isinstance(S_tens_new.data, JaxArray)


### PR DESCRIPTION
Add array and tensor permutation methods.

There is no compiling these, input accept both `array`, `list` and `None`. Pretty much the worth case for `jit`.


@quantshah This complete the dispatched functions for now.
It's more complete than the `Dense` layer, there should only few operations that convert to other types and makes us lose the trace of jax arrays. They will mostly be operations that we have not updated to use v5's data layer yet. 
They are all ready to review and merge, but there will be conflict in `__init__.py`