### PR TITLE
Fix conflict with the present state of Qutip v5

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install QuTiP from GitHub
         run: |
-          python -mpip install git+https://github.com/qutip/qutip.git@dev.major
+          python -mpip install git+https://github.com/qutip/qutip.git@master
           python -c 'import qutip; qutip.about()'
 
       - name: Install qutip-jax from GitHub

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install QuTiP from GitHub
         run: |
-          python -mpip install git+https://github.com/qutip/qutip.git@dev.major
+          python -mpip install git+https://github.com/qutip/qutip.git@master
           python -c 'import qutip; qutip.about()'
 
       - name: Install qutip-jax and dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
         # to see if something hung.
         timeout-minutes: 60
         run: |
-          pytest --durations=0 --durations-min=1.0 --verbosity=1 --cov=qutip_jax --color=yes
+          pytest --durations=0 --durations-min=1.0 --verbosity=1 --cov=qutip_jax --color=yes -W ignore::UserWarning:qutip
           # Above flags are:
           #  --durations=0 --durations-min=1.0
           #     at the end, show a list of all the tests that took longer than a
@@ -69,6 +69,8 @@ jobs:
           #     limit coverage reporting to code that's within the qutip_jax package
           #  --color=yes
           #     force coloured output in the terminal
+          #  -W ignore::UserWarning:qutip
+          #     Ignore matplotlib missing warnings
           # These flags are added to those in pyproject.toml.
 
       - name: Upload to Coveralls

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
-addopts = "-Werror --strict-config --strict-markers  --benchmark-skip"
+addopts = "-Werror --strict-config --strict-markers"
 testpaths = [
     "tests",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,11 +40,5 @@ where = src
 [options.extras_require]
 tests =
     pytest>=6.0
-benchmarks =
-    pytest>=6.0
-    pytest-benchmark>=3.4.1
-    pandas>=1.0
-    matplotlib>=3.0
 full =
     %(tests)s
-    %(benchmarks)s

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,6 @@ def _determine_version(options):
     with open(version_filename, "r") as version_file:
         version_string = version_file.read().strip()
     version = packaging.version.parse(version_string)
-    if isinstance(version, packaging.version.LegacyVersion):
-        raise ValueError("invalid version: " + version_string)
     options['short_version'] = str(version.public)
     options['release'] = not version.is_devrelease
     if not options['release']:

--- a/src/qutip_jax/__init__.py
+++ b/src/qutip_jax/__init__.py
@@ -9,7 +9,7 @@ from .version import version as __version__
 qutip.data.to.add_conversions(
     [
         (JaxArray, qutip.data.Dense, jax_from_dense),
-        (qutip.data.Dense, JaxArray, dense_from_jax),
+        (qutip.data.Dense, JaxArray, dense_from_jax, 2),
     ]
 )
 

--- a/src/qutip_jax/convert.py
+++ b/src/qutip_jax/convert.py
@@ -4,15 +4,16 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
+__all__ = ["is_jax_array", "jax_from_dense", "dense_from_jax"]
+
 # Conversion function
 def jax_from_dense(dense):
     return JaxArray(dense.to_array(), copy=False)
+
 
 def dense_from_jax(jax_array):
     return qutip.data.Dense(jax_array.to_array(), copy=False)
 
 
 def is_jax_array(data):
-    return (
-        isinstance(data, jax.interpreters.xla.DeviceArray)
-    )
+    return isinstance(data, jax.Array)

--- a/src/qutip_jax/measurements.py
+++ b/src/qutip_jax/measurements.py
@@ -32,7 +32,7 @@ def inner_jaxarray(left, right, scalar_is_ket=False):
 
     Returns
     -------
-    out : jax.interpreters.xla.DeviceArray
+    out : jax.Array
         The complex valued output.
     """
     if (left._jxa.shape[0] != 1 and left._jxa.shape[1] != 1) or right._jxa.shape[
@@ -73,7 +73,7 @@ def inner_op_jaxarray(left, op, right, scalar_is_ket=False):
 
     Returns
     -------
-    out : jax.interpreters.xla.DeviceArray
+    out : jax.Array
         The complex valued output.
     """
     left_shape = left._jxa.shape[0] == 1 or left._jxa.shape[1] == 1
@@ -120,7 +120,7 @@ def expect_jaxarray(op, state):
 
     Returns
     -------
-    out : jax.interpreters.xla.DeviceArray
+    out : jax.Array
         The complex valued output.
     """
     if (
@@ -150,7 +150,7 @@ def expect_super_jaxarray(op, state):
 
     Returns
     -------
-    out : jax.interpreters.xla.DeviceArray
+    out : jax.Array
         The complex valued output.
     """
     if state._jxa.shape[1] != 1:

--- a/tests/test_jaxarray.py
+++ b/tests/test_jaxarray.py
@@ -53,7 +53,7 @@ def test_jit():
         return arr.trace()
 
     tr = func(arr)
-    assert isinstance(tr, jax.interpreters.xla.DeviceArray)
+    assert isinstance(tr, jax.Array)
 
 
 @pytest.mark.parametrize("to_",


### PR DESCRIPTION
- Fix the workflow to use `master`.
- Update the naming of Jax array class.
- Remove unneeded dependencies.
- Update convert weight so Dense -> jax is preferred.
- Ignore: UserWarning: matplotlib not found: Graphics will not work.
- Remove check for `packaging.version.LegacyVersion` 

