### PR TITLE
Add `extract_jaxarray` and improve format

### DIFF
--- a/src/qutip_jax/create.py
+++ b/src/qutip_jax/create.py
@@ -113,7 +113,9 @@ def diag_jaxarray(diagonals, offsets=None, shape=None):
             out += jnp.diag(jnp.array(diag), offset)
         out = JaxArray(out)
     else:
-        out = jax_from_dense(qutip.core.data.dense.diags(diagonals, offsets, shape))
+        out = jax_from_dense(
+            qutip.core.data.dense.diags(diagonals, offsets, shape)
+        )
 
     return out
 
@@ -135,12 +137,10 @@ def one_element_jaxarray(shape, position, value=None):
     """
     if not (0 <= position[0] < shape[0] and 0 <= position[1] < shape[1]):
         raise ValueError(
-            "Position of the elements out of bound: "
-            + str(position)
-            + " in "
-            + str(shape)
+            f"Position of the elements out of bound: {position} in {shape}"
         )
-    value = value or 1
+    if value is None:
+        value = 1.0
     out = jnp.zeros(shape, dtype=jnp.complex128)
     return JaxArray(out.at[position].set(value))
 

--- a/src/qutip_jax/jaxarray.py
+++ b/src/qutip_jax/jaxarray.py
@@ -1,14 +1,13 @@
 import jax.numpy as jnp
 from jax import tree_util
 from jax.config import config
+import numbers
+import numpy as np
 
 config.update("jax_enable_x64", True)
 
-import numpy as np
-
 from qutip.core.data.base import Data
-
-import numbers
+from qutip.core.data.extract import extract
 
 
 __all__ = ["JaxArray"]
@@ -107,3 +106,23 @@ class JaxArray(Data):
 tree_util.register_pytree_node(
     JaxArray, JaxArray._tree_flatten, JaxArray._tree_unflatten
 )
+
+
+def extract_jaxarray(matrix, format=None, _=None):
+    """
+    Return ``jaxarray`` as a jax Array.
+
+    Parameters
+    ----------
+    matrix : Data
+        The matrix to convert to common type.
+
+    format : str, {"Array"}
+        Type of the output.
+    """
+    if format not in [None, "Array", "JaxArray"]:
+        raise ValueError("Diag can only be extracted to 'JaxArray'")
+    return matrix._jxa
+
+
+extract.add_specialisations([(JaxArray, extract_jaxarray)], _defer=True)

--- a/src/qutip_jax/jaxarray.py
+++ b/src/qutip_jax/jaxarray.py
@@ -121,7 +121,7 @@ def extract_jaxarray(matrix, format=None, _=None):
         Type of the output.
     """
     if format not in [None, "Array", "JaxArray"]:
-        raise ValueError("Diag can only be extracted to 'JaxArray'")
+        raise ValueError("JaxArray can only be extracted to 'JaxArray'")
     return matrix._jxa
 
 

--- a/src/qutip_jax/measurements.py
+++ b/src/qutip_jax/measurements.py
@@ -37,11 +37,12 @@ def inner_jaxarray(left, right, scalar_is_ket=False):
     out : jax.Array
         The complex valued output.
     """
-    if (left._jxa.shape[0] != 1 and left._jxa.shape[1] != 1) or right._jxa.shape[
-        1
-    ] != 1:
+    if (
+        (left._jxa.shape[0] != 1 and left._jxa.shape[1] != 1)
+        or right._jxa.shape[1] != 1
+    ):
         raise ValueError(
-            "incompatible matrix shapes " + str(left.shape) + " and " + str(right.shape)
+            f"incompatible matrix shapes {left.shape} and {right.shape}"
         )
     if (
         left._jxa.shape[1] == left._jxa.shape[0]
@@ -79,23 +80,16 @@ def inner_op_jaxarray(left, op, right, scalar_is_ket=False):
         The complex valued output.
     """
     left_shape = left._jxa.shape[0] == 1 or left._jxa.shape[1] == 1
-    left_op = (left._jxa.shape[0] == 1 and left._jxa.shape[1] == op._jxa.shape[0]) or (
-        left._jxa.shape[1] == 1 and left._jxa.shape[0] == op._jxa.shape[0]
+    left_op = (
+        (left._jxa.shape[0] == 1 and left._jxa.shape[1] == op._jxa.shape[0])
+        or (left._jxa.shape[1] == 1 and left._jxa.shape[0] == op._jxa.shape[0])
     )
     op_right = op._jxa.shape[1] == right._jxa.shape[0]
     right_shape = right._jxa.shape[1] == 1
     if not (left_shape and left_op and op_right and right_shape):
         raise ValueError(
-            "".join(
-                [
-                    "incompatible matrix shapes ",
-                    str(left.shape),
-                    ", ",
-                    str(op.shape),
-                    " and ",
-                    str(right.shape),
-                ]
-            )
+            "incompatible matrix shapes "
+            f"{left.shape}, {op.shape} and {right.shape}",
         )
     if (
         left._jxa.shape[0] == 1
@@ -131,7 +125,7 @@ def expect_jaxarray(op, state):
         or not (state._jxa.shape[1] == 1 or state._jxa.shape[0] == state._jxa.shape[1])
     ):
         raise ValueError(
-            "incompatible matrix shapes " + str(op.shape) + " and " + str(state.shape)
+            f"incompatible matrix shapes {op.shape} and {state.shape}"
         )
     if state._jxa.shape[0] == state._jxa.shape[1]:
         out = jnp.sum(op._jxa * state._jxa.T)
@@ -158,10 +152,11 @@ def expect_super_jaxarray(op, state):
     if state._jxa.shape[1] != 1:
         raise ValueError("expected a column-stacked matrix")
     if not (
-        op._jxa.shape[0] == op._jxa.shape[1] and op._jxa.shape[1] == state._jxa.shape[0]
+        op._jxa.shape[0] == op._jxa.shape[1]
+        and op._jxa.shape[1] == state._jxa.shape[0]
     ):
         raise ValueError(
-            "incompatible matrix shapes " + str(op.shape) + " and " + str(state.shape)
+            f"incompatible matrix shapes {op.shape} and {state.shape}"
         )
 
     N = int(state._jxa.shape[0] ** 0.5)
@@ -172,9 +167,9 @@ def expect_super_jaxarray(op, state):
 def trace_jaxarray(matrix):
     """Compute the trace (sum of digaonal elements) of a square matrix."""
     if matrix._jxa.shape[0] != matrix._jxa.shape[1]:
-        raise ValueError("".join([
-            "matrix ", str(matrix.shape), " is not a stacked square matrix."
-        ]))
+        raise ValueError(
+            f"matrix {matrix.shape} is not a square matrix."
+        )
     return jnp.trace(matrix._jxa)
 
 
@@ -185,9 +180,9 @@ def trace_oper_ket_jaxarray(matrix):
     """
     N = int(matrix.shape[0] ** 0.5)
     if matrix.shape[0] != N * N or matrix.shape[1] != 1:
-        raise ValueError("".join([
-            "matrix ", str(matrix.shape), " is not a stacked square matrix."
-        ]))
+        raise ValueError(
+            f"matrix {matrix.shape} is not a stacked square matrix."
+        )
     return jnp.sum(matrix._jxa[:: N + 1])
 
 

--- a/src/qutip_jax/ode.py
+++ b/src/qutip_jax/ode.py
@@ -90,7 +90,7 @@ class DiffraxIntegrator(Integrator):
             self.solver_state,
         )
         if self._is_set:
-            children += (self.t, self.state,)
+            children += (self.t, self.state)
         aux_data = {
             "_is_set": self._is_set,
         }
@@ -133,8 +133,8 @@ class DiffraxIntegrator(Integrator):
         Integrator.options.fset(self, new_options)
 
 
-MESolver.add_integrator(DiffraxIntegrator, 'diffrax')
-SESolver.add_integrator(DiffraxIntegrator, 'diffrax')
+MESolver.add_integrator(DiffraxIntegrator, "diffrax")
+SESolver.add_integrator(DiffraxIntegrator, "diffrax")
 jax.tree_util.register_pytree_node(
     DiffraxIntegrator, DiffraxIntegrator._flatten, DiffraxIntegrator._unflatten
 )

--- a/src/qutip_jax/qobjevo.py
+++ b/src/qutip_jax/qobjevo.py
@@ -37,27 +37,33 @@ class JaxJitCoeff(Coefficient):
 
     def __add__(self, other):
         if isinstance(other, JaxJitCoeff):
+
             def f(t, **kwargs):
                 return self(t, **kwargs) + other(t, **kwargs)
             return JaxJitCoeff(eqx.filter_jit(f), {})
+
         return NotImplemented
 
     def __mul__(self, other):
         if isinstance(other, JaxJitCoeff):
+
             def f(t, **kwargs):
                 return self(t, **kwargs) * other(t, **kwargs)
             return JaxJitCoeff(eqx.filter_jit(f), {})
+
         return NotImplemented
 
     def conj(self):
         def f(t, **kwargs):
             return jnp.conj(self(t, **kwargs))
+
         return JaxJitCoeff(eqx.filter_jit(f), {})
 
     def _cdc(self):
         def f(t, **kwargs):
             val = self(t, **kwargs)
             return jnp.conj(val) * val
+
         return JaxJitCoeff(eqx.filter_jit(f), {})
 
     def copy(self):
@@ -94,6 +100,7 @@ class JaxQobjEvo(eqx.Module):
 
     It only support list based `QobjEvo`.
     """
+
     batched_data: jnp.ndarray
     coeffs: list
     dims: object = eqx.static_field()
@@ -104,15 +111,14 @@ class JaxQobjEvo(eqx.Module):
         qobjs = []
         self.dims = qobjevo.dims
 
-        constant = JaxJitCoeff(eqx.filter_jit(lambda t, **_: 1.))
+        constant = JaxJitCoeff(eqx.filter_jit(lambda t, **_: 1.0))
 
         for part in as_list:
             if isinstance(part, Qobj):
                 qobjs.append(part)
                 self.coeffs.append(constant)
             elif (
-                isinstance(part, list)
-                and isinstance(part[0], Qobj)
+                isinstance(part, list) and isinstance(part[0], Qobj)
             ):
                 qobjs.append(part[0])
                 self.coeffs.append(part[1])

--- a/src/qutip_jax/reshape.py
+++ b/src/qutip_jax/reshape.py
@@ -18,10 +18,9 @@ __all__ = [
 # jit slower
 def reshape_jaxarray(matrix, n_rows_out, n_cols_out):
     if n_rows_out * n_cols_out != matrix.shape[0] * matrix.shape[1]:
-        message = "".join([
-            "cannot reshape ", str(matrix.shape), " to ",
-            "(", str(n_rows_out), ", ", str(n_cols_out), ")",
-        ])
+        message = (
+            f"cannot reshape {matrix.shape} to ({n_rows_out}, {n_cols_out})"
+        )
         raise ValueError(message)
     if n_rows_out <= 0 or n_cols_out <= 0:
         raise ValueError("must have > 0 rows and columns")
@@ -71,14 +70,17 @@ def _parse_ptrace_inputs(dims, sel, shape):
         raise ValueError("ptrace is only defined for square density matrices")
 
     if shape[0] != np.prod(dims, dtype=int):
-        raise ValueError(f"the input matrix shape, {shape} and the"
-                         f" dimension argument, {dims}, are not compatible.")
+        raise ValueError(
+            f"the input matrix shape, {shape} and the"
+            f" dimension argument, {dims}, are not compatible."
+        )
     if sel.ndim != 1:
         raise ValueError("Selection must be one-dimensional")
 
     if any(d < 1 for d in dims):
-        raise ValueError("dimensions must be greated than zero but where"
-                         f" dims={dims}.")
+        raise ValueError(
+            f"dimensions must be greated than zero but where dims={dims}."
+        )
 
     for i in range(sel.shape[0]):
         if sel[i] < 0 or sel[i] >= dims.size:

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -37,4 +37,4 @@ def test_QobjEvo_flatten():
 
     # This call require jit to be able to jit QobjEvos
     assert func(0.5, H, state) == pytest.approx(expect(H(0.5), state))
-    assert func(1.5, H, state)  == pytest.approx(expect(H(1.5), state))
+    assert func(1.5, H, state) == pytest.approx(expect(H(1.5), state))

--- a/tests/test_jaxarray.py
+++ b/tests/test_jaxarray.py
@@ -82,8 +82,8 @@ def test_convert():
     """Tests if the conversions from Qobj to JaxArray work"""
     ones = jnp.ones((3, 3))
     qobj = qutip.Qobj(ones)
-    prod = qobj * jnp.array([0.5])
-    assert_array_almost_equal(prod.data.to_array(), ones * jnp.array([0.5]))
+    prod = qobj * jnp.array(0.5)
+    assert_array_almost_equal(prod.data.to_array(), ones * jnp.array(0.5))
 
     sx = qutip.qeye(5, dtype="csr")
     assert isinstance(sx.data, qutip.core.data.CSR)

--- a/tests/test_jaxarray.py
+++ b/tests/test_jaxarray.py
@@ -91,3 +91,9 @@ def test_convert():
 
     sx = qutip.qeye(5, dtype="JaxArray")
     assert isinstance(sx.data, JaxArray)
+
+
+def test_extract():
+    ones = jnp.ones((3, 3))
+    qobj = qutip.Qobj(ones)
+    assert isinstance(qobj.data_as("JaxArray"), jax.Array)

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -10,7 +10,7 @@ from qutip.core import data as _data
 from qutip.core.data import Data, Dense, CSR
 
 
-class TestSolve():
+class TestSolve:
     def op_numpy(self, A, b):
         return np.linalg.solve(A, b)
 
@@ -20,7 +20,7 @@ class TestSolve():
     def _gen_ket(self, N, dtype):
         return qutip.rand_ket(N, dtype=dtype).data
 
-    @pytest.mark.parametrize('method', ["solve", "lstsq"])
+    @pytest.mark.parametrize("method", ["solve", "lstsq"])
     def test_mathematically_correct_JaxArray(self, method):
         A = self._gen_op(10, JaxArray)
         b = self._gen_ket(10, JaxArray)
@@ -29,27 +29,25 @@ class TestSolve():
         test1 = _data.solve(A, b, method)
 
         assert test.shape == expected.shape
-        np.testing.assert_allclose(test.to_array(), expected,
-                                   atol=1e-7, rtol=1e-7)
-        np.testing.assert_allclose(test1.to_array(), expected,
-                                   atol=1e-7, rtol=1e-7)
+        np.testing.assert_allclose(test.to_array(), expected, atol=1e-7, rtol=1e-7)
+        np.testing.assert_allclose(test1.to_array(), expected, atol=1e-7, rtol=1e-7)
 
     def test_incorrect_shape_non_square(self):
         key = jax.random.PRNGKey(1)
-        A = JaxArray(jax.random.uniform(shape=(2,3), key=key))
-        b = JaxArray(jax.random.uniform(shape=(3,1), key=key))
+        A = JaxArray(jax.random.uniform(shape=(2, 3), key=key))
+        b = JaxArray(jax.random.uniform(shape=(3, 1), key=key))
         with pytest.raises(ValueError):
             test1 = solve_jaxarray(A, b)
 
     def test_incorrect_shape_mismatch(self):
         key = jax.random.PRNGKey(1)
-        A = JaxArray(jax.random.uniform(shape=(3,3), key=key))
-        b = JaxArray(jax.random.uniform(shape=(2,1), key=key))
+        A = JaxArray(jax.random.uniform(shape=(3, 3), key=key))
+        b = JaxArray(jax.random.uniform(shape=(2, 1), key=key))
         with pytest.raises(ValueError):
             test1 = solve_jaxarray(A, b)
 
 
-class TestSVD():
+class TestSVD:
     def op_numpy(self, A):
         return np.linalg.svd(A)
 
@@ -57,10 +55,10 @@ class TestSVD():
         return qutip.rand_dm(N, rank=rank, dtype=dtype).data
 
     def _gen_non_square(self, N):
-        mat = np.random.randn(N, N//2)
-        for i in range(N//2):
+        mat = np.random.randn(N, N // 2)
+        for i in range(N // 2):
             # Ensure no zeros singular values
-            mat[i,i] += 5
+            mat[i, i] += 5
         return _data.Dense(mat)
 
     @pytest.mark.parametrize("shape", ["square", "non-square"])
@@ -92,5 +90,6 @@ class TestSVD():
         np.testing.assert_allclose(
             matrix.to_array(),
             (test_U @ s_as_matrix @ test_V).to_array(),
-            atol=1e-7, rtol=1e-7
+            atol=1e-7,
+            rtol=1e-7,
         )

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -49,7 +49,7 @@ class TestSolve:
 
 class TestSVD:
     def op_numpy(self, A):
-        return np.linalg.svd(A)
+        return jax.numpy.linalg.svd(A)
 
     def _gen_dm(self, N, rank, dtype):
         return qutip.rand_dm(N, rank=rank, dtype=dtype).data

--- a/tests/test_norm.py
+++ b/tests/test_norm.py
@@ -25,7 +25,6 @@ class TestOneNorm(testing_norm.TestOneNorm):
     ]
 
 
-
 class TestFrobeniusNorm(testing_norm.TestFrobeniusNorm):
     specialisations = [
         pytest.param(
@@ -34,7 +33,6 @@ class TestFrobeniusNorm(testing_norm.TestFrobeniusNorm):
             object,
         )
     ]
-
 
 
 class TestMaxNorm(testing_norm.TestMaxNorm):
@@ -47,7 +45,6 @@ class TestMaxNorm(testing_norm.TestMaxNorm):
     ]
 
 
-
 class TestL2Norm(testing_norm.TestL2Norm):
     specialisations = [
         pytest.param(
@@ -56,7 +53,6 @@ class TestL2Norm(testing_norm.TestL2Norm):
             object,
         )
     ]
-
 
 
 class TestTraceNorm(testing_norm.TestTraceNorm):


### PR DESCRIPTION
- Add the specialisation for `extract` and a test.
- Also improve formatting both manually and with black.
- Fix svd test. numpy's and jax's `svd` function return valid decomposition, but not the exact same result.