### PR TITLE
Allow other `dtype` than complex128.

### DIFF
--- a/src/qutip_jax/binops.py
+++ b/src/qutip_jax/binops.py
@@ -74,7 +74,7 @@ def mul_jaxarray(matrix, value):
     # We don't want to check values type in case jax pass a tracer etc.
     # But we want to ensure the output is a matrix, thus don't use the
     # fast constructor.
-    return JaxArray(matrix._jxa * value)
+    return JaxArray._fast_constructor(matrix._jxa * value, shape=matrix.shape)
 
 
 def matmul_jaxarray(left, right, scale=1, out=None):
@@ -119,7 +119,7 @@ def kron_jaxarray(left, right):
     Compute the Kronecker product of two matrices.  This is used to represent
     quantum tensor products of vector spaces.
     """
-    return JaxArray(jnp.kron(left._jxa, right._jxa))
+    return JaxArray._fast_constructor(jnp.kron(left._jxa, right._jxa))
 
 
 def pow_jaxarray(matrix, n):
@@ -138,7 +138,7 @@ def pow_jaxarray(matrix, n):
     """
     if matrix.shape[0] != matrix.shape[1]:
         raise ValueError("matrix power only works with square matrices")
-    return JaxArray(jnp.linalg.matrix_power(matrix._jxa, n))
+    return JaxArray._fast_constructor(jnp.linalg.matrix_power(matrix._jxa, n))
 
 
 qutip.data.add.add_specialisations(

--- a/src/qutip_jax/create.py
+++ b/src/qutip_jax/create.py
@@ -25,7 +25,7 @@ def zeros_jaxarray(rows, cols, *, dtype=jnp.complex128):
         rows, cols : int
             The number of rows and columns in the output matrix.
     """
-    return JaxArray(jnp.zeros((rows, cols), dtype=dtype))
+    return JaxArray._fast_constructor(jnp.zeros((rows, cols), dtype=dtype))
 
 
 def identity_jaxarray(dimensions, scale=None, *, dtype=jnp.complex128):
@@ -43,8 +43,8 @@ def identity_jaxarray(dimensions, scale=None, *, dtype=jnp.complex128):
         The element which should be placed on the diagonal.
     """
     if scale is None:
-        return JaxArray(jnp.eye(dimensions, dtype=dtype))
-    return JaxArray(jnp.eye(dimensions, dtype=dtype) * scale)
+        return JaxArray._fast_constructor(jnp.eye(dimensions, dtype=dtype))
+    return JaxArray._fast_constructor(jnp.eye(dimensions, dtype=dtype) * scale)
 
 
 def diag_jaxarray(diagonals, offsets=None, shape=None, *, dtype=jnp.complex128):
@@ -111,7 +111,7 @@ def diag_jaxarray(diagonals, offsets=None, shape=None, *, dtype=jnp.complex128):
         out = jnp.zeros((n_rows, n_cols), dtype=dtype)
         for offset, diag in zip(offsets, diagonals):
             out += jnp.diag(jnp.array(diag), offset)
-        out = JaxArray(out)
+        out = JaxArray._fast_constructor(out)
     else:
         out = jax_from_dense(qutip.core.data.dense.diags(diagonals, offsets, shape))
 
@@ -142,7 +142,7 @@ def one_element_jaxarray(shape, position, value=None, *, dtype=jnp.complex128):
         )
     value = value or 1
     out = jnp.zeros(shape, dtype=dtype)
-    return JaxArray(out.at[position].set(value))
+    return JaxArray._fast_constructor(out.at[position].set(value))
 
 
 qutip.data.zeros.add_specialisations(

--- a/src/qutip_jax/create.py
+++ b/src/qutip_jax/create.py
@@ -16,7 +16,7 @@ __all__ = [
 ]
 
 
-def zeros_jaxarray(rows, cols):
+def zeros_jaxarray(rows, cols, *, dtype=jnp.complex128):
     """
     Creates a matrix representation of zeros with the given dimensions.
 
@@ -25,10 +25,10 @@ def zeros_jaxarray(rows, cols):
         rows, cols : int
             The number of rows and columns in the output matrix.
     """
-    return JaxArray(jnp.zeros((rows, cols), dtype=jnp.complex128))
+    return JaxArray(jnp.zeros((rows, cols), dtype=dtype))
 
 
-def identity_jaxarray(dimensions, scale=None):
+def identity_jaxarray(dimensions, scale=None, *, dtype=jnp.complex128):
     """
     Creates a square identity matrix of the given dimension.
 
@@ -43,11 +43,11 @@ def identity_jaxarray(dimensions, scale=None):
         The element which should be placed on the diagonal.
     """
     if scale is None:
-        return JaxArray(jnp.eye(dimensions, dtype=jnp.complex128))
-    return JaxArray(jnp.eye(dimensions, dtype=jnp.complex128) * scale)
+        return JaxArray(jnp.eye(dimensions, dtype=dtype))
+    return JaxArray(jnp.eye(dimensions, dtype=dtype) * scale)
 
 
-def diag_jaxarray(diagonals, offsets=None, shape=None):
+def diag_jaxarray(diagonals, offsets=None, shape=None, *, dtype=jnp.complex128):
     """
     Constructs a matrix from diagonals and their offsets.
 
@@ -108,7 +108,7 @@ def diag_jaxarray(diagonals, offsets=None, shape=None):
 
     if n_rows == n_cols:
         # jax diag only create square matrix
-        out = jnp.zeros((n_rows, n_cols), dtype=jnp.complex128)
+        out = jnp.zeros((n_rows, n_cols), dtype=dtype)
         for offset, diag in zip(offsets, diagonals):
             out += jnp.diag(jnp.array(diag), offset)
         out = JaxArray(out)
@@ -118,7 +118,7 @@ def diag_jaxarray(diagonals, offsets=None, shape=None):
     return out
 
 
-def one_element_jaxarray(shape, position, value=None):
+def one_element_jaxarray(shape, position, value=None, *, dtype=jnp.complex128):
     """
     Creates a matrix with only one nonzero element.
 
@@ -141,7 +141,7 @@ def one_element_jaxarray(shape, position, value=None):
             + str(shape)
         )
     value = value or 1
-    out = jnp.zeros(shape, dtype=jnp.complex128)
+    out = jnp.zeros(shape, dtype=dtype)
     return JaxArray(out.at[position].set(value))
 
 

--- a/src/qutip_jax/jaxarray.py
+++ b/src/qutip_jax/jaxarray.py
@@ -18,7 +18,7 @@ class JaxArray(Data):
     _jxa: jnp.ndarray
     shape: tuple
 
-    def __init__(self, data, shape=None, copy=None, *, dtype=None):
+    def __init__(self, data, shape=None, copy=None, *, dtype=jnp.complex128):
         jxa = jnp.array(data, dtype=dtype)
 
         if shape is None:
@@ -82,8 +82,10 @@ class JaxArray(Data):
         return NotImplemented
 
     @classmethod
-    def _fast_constructor(cls, array, shape):
+    def _fast_constructor(cls, array, shape=None):
         out = cls.__new__(cls)
+        if shape is None:
+            shape = array.shape
         Data.__init__(out, shape)
         out._jxa = array
         return out

--- a/src/qutip_jax/jaxarray.py
+++ b/src/qutip_jax/jaxarray.py
@@ -18,8 +18,8 @@ class JaxArray(Data):
     _jxa: jnp.ndarray
     shape: tuple
 
-    def __init__(self, data, shape=None, copy=None):
-        jxa = jnp.array(data, dtype=jnp.complex128)
+    def __init__(self, data, shape=None, copy=None, *, dtype=None):
+        jxa = jnp.array(data, dtype=dtype)
 
         if shape is None:
             shape = data.shape
@@ -46,19 +46,19 @@ class JaxArray(Data):
         Data.__init__(self, shape)
 
     def copy(self):
-        return self.__class__(self._jxa, copy=True)
+        return JaxArray._fast_constructor(self._jxa.copy(), shape=self.shape)
 
     def to_array(self):
         return np.array(self._jxa)
 
     def conj(self):
-        return self.__class__(self._jxa.conj())
+        return JaxArray._fast_constructor(self._jxa.conj(), shape=self.shape)
 
     def transpose(self):
-        return self.__class__(self._jxa.T)
+        return JaxArray._fast_constructor(self._jxa.T, shape=self.shape[::-1])
 
     def adjoint(self):
-        return self.__class__(self._jxa.T.conj())
+        return JaxArray._fast_constructor(self._jxa.T.conj(), shape=self.shape[::-1])
 
     def trace(self):
         return jnp.trace(self._jxa)

--- a/src/qutip_jax/linalg.py
+++ b/src/qutip_jax/linalg.py
@@ -65,7 +65,7 @@ def eigs_jaxarray(data, isherm=None, vecs=True, sort='low', eigvals=0):
 
     evals, evecs = _eigs_jaxarray(data._jxa, isherm, vecs, eigvals, low_first)
 
-    return (evals, JaxArray(evecs, copy=False)) if vecs else evals
+    return (evals, JaxArray._fast_constructor(evecs)) if vecs else evals
 
 
 qutip.data.eigs.add_specialisations(
@@ -109,7 +109,7 @@ def svd_jaxarray(data, vecs=True, full_matrices=True, hermitian=False):
     )
     if vecs:
         u, s, vh = out
-        return JaxArray(u, copy=False), s, JaxArray(vh, copy=False)
+        return JaxArray._fast_constructor(u), s, JaxArray._fast_constructor(vh)
     return out
 
 
@@ -160,7 +160,7 @@ def solve_jaxarray(matrix: JaxArray, target: JaxArray, method=None,
     else:
         raise ValueError(f"Unknown solver {method},"
                          " 'solve' and 'lstsq' are supported.")
-    return JaxArray(out, copy=False)
+    return JaxArray._fast_constructor(out)
 
 
 qutip.data.solve.add_specialisations(

--- a/src/qutip_jax/ode.py
+++ b/src/qutip_jax/ode.py
@@ -14,12 +14,16 @@ __all__ = []
 
 @jax.jit
 def _cplx2float(arr):
-    return jnp.stack([arr.real, arr.imag])
+    if jnp.iscomplexobj(arr):
+        return jnp.stack([arr.real, arr.imag])
+    return arr
 
 
 @jax.jit
 def _float2cplx(arr):
-    return arr[0] + 1j * arr[1]
+    if arr.ndim == 3:
+        return arr[0] + 1j * arr[1]
+    return arr
 
 
 class DiffraxIntegrator(Integrator):
@@ -49,7 +53,7 @@ class DiffraxIntegrator(Integrator):
     def dstate(t, y, args):
         state = _float2cplx(y)
         H, kwargs = args
-        d_state = H.matmul_data(t, JaxArray(state), **kwargs)
+        d_state = H.matmul_data(t, JaxArray._fast_constructor(state), **kwargs)
         return _cplx2float(d_state._jxa)
 
     def set_state(self, t, state0):
@@ -61,7 +65,7 @@ class DiffraxIntegrator(Integrator):
         self._is_set = True
 
     def get_state(self, copy=False):
-        return self.t, JaxArray(_float2cplx(self.state))
+        return self.t, JaxArray._fast_constructor(_float2cplx(self.state))
 
     def integrate(self, t, copy=False, **kwargs):
         sol = diffrax.diffeqsolve(

--- a/src/qutip_jax/permute.py
+++ b/src/qutip_jax/permute.py
@@ -12,7 +12,7 @@ def indices_jaxarray(matrix, row_perm=None, col_perm=None):
         data = data[np.argsort(row_perm), :]
     if col_perm is not None:
         data = data[:, np.argsort(col_perm)]
-    return JaxArray(data)
+    return JaxArray._fast_constructor(data)
 
 
 def dimensions_jaxarray(matrix, dimensions, order):

--- a/src/qutip_jax/qobjevo.py
+++ b/src/qutip_jax/qobjevo.py
@@ -97,7 +97,6 @@ class JaxQobjEvo(eqx.Module):
     batched_data: jnp.ndarray
     coeffs: list
     dims: object = eqx.static_field()
-    dtype: jnp.dtype
 
     def __init__(self, qobjevo):
         as_list = qobjevo.to_list()
@@ -131,7 +130,6 @@ class JaxQobjEvo(eqx.Module):
 
         if dtype is None:
             dtype=jnp.complex128
-        self.dtype = dtype
 
         if qobjs:
             shape = qobjs[0].shape

--- a/src/qutip_jax/qobjevo.py
+++ b/src/qutip_jax/qobjevo.py
@@ -5,7 +5,7 @@ import jax.numpy as jnp
 import numpy as np
 from .jaxarray import JaxArray
 from qutip.core.coefficient import coefficient_builders
-from qutip.core.cy.coefficient import Coefficient
+from qutip.core.cy.coefficient import Coefficient, coefficient_function_parameters
 from qutip import Qobj
 
 
@@ -18,16 +18,26 @@ class JaxJitCoeff(Coefficient):
 
     def __init__(self, func, args={}, **_):
         self.func = func
+        _f_pythonic, _f_parameters = coefficient_function_parameters(func)
+        if _f_parameters is not None:
+            args = {key:val for key, val in args.items() if key in _f_parameters}
+        else:
+            args = args.copy()
+        if not _f_pythonic:
+            raise TypeError("Jitted coefficient should use a pythonic signature.")
         Coefficient.__init__(self, args)
 
     @eqx.filter_jit
     def __call__(self, t, _args=None, **kwargs):
         if _args:
             kwargs.update(_args)
-        args = self.args.copy()
-        for key in kwargs:
-            if key in args:
-                args[key] = kwargs[key]
+        if kwargs:
+            args = self.args.copy()
+            for key in kwargs:
+                if key in args:
+                    args[key] = kwargs[key]
+        else:
+            args = self.args
         return self.func(t, **args)
 
     def replace_arguments(self, _args=None, **kwargs):
@@ -153,12 +163,12 @@ class JaxQobjEvo(eqx.Module):
     def data(self, t, **kwargs):
         coeff = self._coeff(t, **kwargs)
         data = jnp.dot(self.batched_data, coeff)
-        return JaxArray(data)
+        return JaxArray._fast_constructor(data)
 
     @eqx.filter_jit
     def matmul_data(self, t, y, **kwargs):
         coeffs = self._coeff(t, **kwargs)
-        out = JaxArray(jnp.dot(jnp.dot(self.batched_data, coeffs), y._jxa))
+        out = JaxArray._fast_constructor(jnp.dot(jnp.dot(self.batched_data, coeffs), y._jxa))
         return out
 
     def arguments(self, args):

--- a/src/qutip_jax/reshape.py
+++ b/src/qutip_jax/reshape.py
@@ -58,7 +58,7 @@ def column_unstack_jaxarray(matrix, rows):
 @jit
 def split_columns_jaxarray(matrix):
     return [
-        JaxArray(matrix._jxa[:, k]) for k in range(matrix.shape[1])
+        JaxArray._fast_constructor(matrix._jxa[:, k:k+1]) for k in range(matrix.shape[1])
     ]
 
 
@@ -117,7 +117,7 @@ def ptrace_jaxarray(matrix, dims, sel):
         + sel + [nd + q for q in sel]
     )
 
-    return JaxArray(
+    return JaxArray._fast_constructor(
         _ptrace_core(matrix._jxa, dims2, transpose_idx, dtrace, dkeep)
     )
 

--- a/src/qutip_jax/unary.py
+++ b/src/qutip_jax/unary.py
@@ -31,12 +31,12 @@ def neg_jaxarray(matrix):
 @jit
 def adjoint_jaxarray(matrix):
     """Hermitian adjoint (matrix conjugate transpose)."""
-    return JaxArray(matrix._jxa.T.conj())
+    return JaxArray._fast_constructor(matrix._jxa.T.conj())
 
 
 def transpose_jaxarray(matrix):
     """Transpose of a matrix."""
-    return JaxArray(matrix._jxa.T)
+    return JaxArray._fast_constructor(matrix._jxa.T)
 
 
 def conj_jaxarray(matrix):
@@ -79,7 +79,7 @@ def project_jaxarray(state):
         out = _project_bra(state._jxa)
     else:
         raise ValueError("state must be a ket or a bra.")
-    return JaxArray(out)
+    return JaxArray._fast_constructor(out)
 
 
 qutip.data.neg.add_specialisations(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,6 @@ import qutip_jax
 key = random.PRNGKey(1234)
 
 def _random_cplx(shape):
-    return qutip_jax.JaxArray(
+    return qutip_jax.JaxArray._fast_constructor(
         random.normal(key, shape) + 1j*random.normal(key, shape)
     )

--- a/tests/test_jaxarray.py
+++ b/tests/test_jaxarray.py
@@ -23,7 +23,6 @@ def test_init(backend, shape, dtype):
     array = backend.array(array)
     jax_a = JaxArray(array)
     assert isinstance(jax_a, JaxArray)
-    assert jax_a._jxa.dtype == jax.numpy.complex128
     if len(shape) == 1:
         shape = shape + (1,)
     assert jax_a.shape == shape
@@ -91,3 +90,12 @@ def test_convert():
 
     sx = qutip.qeye(5, dtype="JaxArray")
     assert isinstance(sx.data, JaxArray)
+
+
+def test_alternative_dtype():
+    ones = jnp.ones((3, 3))
+    real_array = JaxArray(ones, dtype=jnp.float64)
+    cplx_array = JaxArray(ones*1j, dtype=jnp.complex64)
+    assert (real_array * 5.)._jxa.dtype == jnp.float64
+    assert (cplx_array + cplx_array)._jxa.dtype == jnp.complex64
+    assert (cplx_array @ real_array)._jxa.dtype == jnp.complex128

--- a/tests/test_jaxarray.py
+++ b/tests/test_jaxarray.py
@@ -98,4 +98,7 @@ def test_alternative_dtype():
     cplx_array = JaxArray(ones*1j, dtype=jnp.complex64)
     assert (real_array * 5.)._jxa.dtype == jnp.float64
     assert (cplx_array + cplx_array)._jxa.dtype == jnp.complex64
-    assert (cplx_array @ real_array)._jxa.dtype == jnp.complex128
+
+    cplx_array = JaxArray(ones*1j, dtype=jnp.complex64)
+    real_array = JaxArray(ones, dtype=jnp.float32)
+    assert (cplx_array @ real_array)._jxa.dtype == jnp.complex64


### PR DESCRIPTION
Our data layer always use double precision complex, but this is not always ideals, GPUs often don's support double precision well.

With this, the default is still to convert any array to complex128, but it can be overwritten.
However, this is not usable trough the Qutip interface with this PR. I am not too sure how to make it available to the user....
