### PR TITLE
Update for jax 0.4.23 and dimensions PR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
         # to see if something hung.
         timeout-minutes: 60
         run: |
-          pytest --durations=0 --durations-min=1.0 --verbosity=1 --cov=qutip_jax --cov-report= --color=yes -W ignore::UserWarning:qutip
+          pytest --durations=0 --durations-min=1.0 --verbosity=1 --cov=qutip_jax --cov-report= --color=yes -W ignore::UserWarning:qutip -W "ignore:Complex dtype:UserWarning"
           # Above flags are:
           #  --durations=0 --durations-min=1.0
           #     at the end, show a list of all the tests that took longer than a

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -64,7 +64,7 @@ jobs:
         # to see if something hung.
         timeout-minutes: 60
         run: |
-          pytest --durations=0 --durations-min=1.0 --verbosity=1 --color=yes -W ignore::UserWarning:qutip
+          pytest --durations=0 --durations-min=1.0 --verbosity=1 --color=yes -W ignore::UserWarning:qutip -W "ignore:Complex dtype:UserWarning"
           # Above flags are:
           #  --durations=0 --durations-min=1.0
           #     at the end, show a list of all the tests that took longer than a

--- a/src/qutip_jax/jaxarray.py
+++ b/src/qutip_jax/jaxarray.py
@@ -1,6 +1,5 @@
 import jax.numpy as jnp
-from jax import tree_util
-from jax.config import config
+from jax import tree_util, config
 import numbers
 import numpy as np
 

--- a/src/qutip_jax/ode.py
+++ b/src/qutip_jax/ode.py
@@ -1,5 +1,4 @@
 import diffrax
-import warnings
 from qutip.solver.integrator import Integrator
 import jax
 import jax.numpy as jnp
@@ -65,22 +64,16 @@ class DiffraxIntegrator(Integrator):
         return self.t, JaxArray(_float2cplx(self.state))
 
     def integrate(self, t, copy=False, **kwargs):
-        with warnings.catch_warnings():
-            # Diffrax added partial support for complex number, but raise a
-            # warning when it find a complex anywhere in the tree.
-            warnings.filterwarnings("ignore",
-                message="Complex dtype support is work in progress,"
-            )
-            sol = diffrax.diffeqsolve(
-                self.ODEsystem,
-                t0=self.t,
-                t1=t,
-                y0=self.state,
-                saveat=diffrax.SaveAt(t1=True, solver_state=True),
-                solver_state=self.solver_state,
-                args=(self.system, kwargs),
-                **self._options,
-            )
+        sol = diffrax.diffeqsolve(
+            self.ODEsystem,
+            t0=self.t,
+            t1=t,
+            y0=self.state,
+            saveat=diffrax.SaveAt(t1=True, solver_state=True),
+            solver_state=self.solver_state,
+            args=(self.system, kwargs),
+            **self._options,
+        )
         self.t = t
         self.state = sol.ys[0, :]
         self.solver_state = sol.solver_state

--- a/src/qutip_jax/qutip_trees.py
+++ b/src/qutip_jax/qutip_trees.py
@@ -9,9 +9,7 @@ __all__ = []
 def qobj_tree_flatten(qobj):
     children = (qobj.to("jax").data,)
     aux_data = {
-        "dims": qobj.dims,
-        "type": qobj.type,
-        "superrep": qobj.superrep,
+        "_dims": qobj._dims,
         # Attribute that depend on the data are not safe to be set.
         "_isherm": None,
         "_isunitary": None,


### PR DESCRIPTION
Current jax changed the config import.
Also the dimensions PR change the way we need to unflatten `Qobj`.

Diffrax now raise a warning anytime any array is complex in it's input, so always for us.