### PR TITLE
Changes ode default step size to PIDController

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
-addopts = "-Werror --strict-config --strict-markers"
+addopts = "-Werror --strict-config --strict-markers -W \"ignore:Complex dtype:UserWarning\""
 testpaths = [
     "tests",
 ]

--- a/src/qutip_jax/ode.py
+++ b/src/qutip_jax/ode.py
@@ -29,7 +29,7 @@ class DiffraxIntegrator(Integrator):
     integrator_options: dict = {
         "dt0": 0.0001,
         "solver": diffrax.Tsit5(),
-        "stepsize_controller": diffrax.ConstantStepSize(),
+        "stepsize_controller": diffrax.PIDController(atol=1e-8, rtol=1e-6),
         "max_steps": 100000,
     }
 


### PR DESCRIPTION
Constant steps are often far from optimal.
This sets the default to be variable step length with tolerance default matching those of other integrators.