### PR TITLE
Failing weekly test open issue instead of sending email.

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -12,7 +12,6 @@ on:
     inputs:
       open_issue:
         description: 'Open issue on failure'
-        required: false
         default: "False"
 
 
@@ -33,11 +32,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: [3.11]
         case-name: [defaults]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
@@ -88,7 +87,7 @@ jobs:
     if: failure()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Open Issue on Failure
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -94,6 +94,6 @@ jobs:
         run: |
           if [[ -z "${{ inputs.open_issue }}" ]] || [[ "${{ inputs.open_issue }}" != "False" ]];
           then
-            pip install requests argparse datetime
+            pip install requests
             python tools/report_failing_tests.py $GITHUB_TOKEN
           fi

--- a/tools/report_failing_tests.py
+++ b/tools/report_failing_tests.py
@@ -5,7 +5,7 @@ import argparse
 from datetime import date
 
 def open_issue(token):
-    url = "https://api.github.com/repos/ericgig/qutip-jax/issues"
+    url = "https://api.github.com/repos/qutip/qutip-jax/issues"
     data = json.dumps({
         "title": f"Automated tests failed on {date.today()}",
         "labels": ["bug"],


### PR DESCRIPTION
Weekly tests tried to send email on failure, but they were filtered and never received...

This update the warning to opening an issue when instead.

Half of this PR was merged per error in #42 when I tried to merge it into my fork's master to tests to tests the action on github runner.

Example of opened issue: ericgig/qutip-jax#4