### PR TITLE
Fix for updates in jax and qutip

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: [3.11]
         case-name: [defaults]
 
     steps:

--- a/src/qutip_jax/__init__.py
+++ b/src/qutip_jax/__init__.py
@@ -12,8 +12,8 @@ qutip.data.to.add_conversions(
         (JaxArray, qutip.data.Dense, jaxarray_from_dense),
         (qutip.data.Dense, JaxArray, dense_from_jaxarray, 2),
         (JaxArray, JaxDia, jaxarray_from_jaxdia),
-        (JaxDia, JaxArray, jaxdia_from_jaxarray),
-        (qutip.data.Dia, JaxDia, dia_from_jaxdia),
+        (JaxDia, JaxArray, jaxdia_from_jaxarray, 1.2),
+        (qutip.data.Dia, JaxDia, dia_from_jaxdia, 2),
         (JaxDia, qutip.data.Dia, jaxdia_from_dia),
     ]
 )

--- a/tests/test_ode.py
+++ b/tests/test_ode.py
@@ -36,6 +36,8 @@ def cte(t, A):
     return A
 
 
+# diffrax use clip with deprecated parameters
+@pytest.mark.filterwarnings("ignore:Passing arguments 'a'")
 @pytest.mark.parametrize("dtype", ("jax", "jaxdia"))
 def test_ode_run(dtype):
     with CoreOptions(default_dtype=dtype):
@@ -57,6 +59,7 @@ def test_ode_run(dtype):
     np.testing.assert_allclose(result.expect[0], expected.expect[0], atol=1e-6)
 
 
+@pytest.mark.filterwarnings("ignore:Passing arguments 'a'")
 @pytest.mark.parametrize("dtype", ("jax", "jaxdia"))
 def test_ode_step(dtype):
     with CoreOptions(default_dtype=dtype):
@@ -79,6 +82,7 @@ def test_ode_step(dtype):
     assert (solver.step(1) - ref_solver.step(1)).norm() <= 1e-6
 
 
+@pytest.mark.filterwarnings("ignore:Passing arguments 'a'")
 @pytest.mark.parametrize("dtype", ("jax", "jaxdia"))
 def test_ode_grad(dtype):
     with CoreOptions(default_dtype=dtype):


### PR DESCRIPTION
- Filter warning from jax 0.4.28.
- Update weight so `==` does not fallback to `Dia`, but `Dense`.
- Use python 3.11 for tests instead of 3.9.