### PR TITLE
fix _eigs_jaxarray to be compatible with jit

### DIFF
--- a/src/qutip_jax/linalg.py
+++ b/src/qutip_jax/linalg.py
@@ -14,40 +14,51 @@ __all__ = [
 
 def herm_with_vecs(data):
     evals, evecs = jnp.linalg.eigh(data)
-    evals, evecs = evals.astype(jnp.complex64), evecs.astype(jnp.complex64)
-    return (evals, evecs)
+    evals, evecs = evals.astype(data.dtype), evecs.astype(data.dtype)
+    return evals, evecs
 
 def nonherm_with_vecs(data):
     evals, evecs = jnp.linalg.eig(data)
-    evals, evecs = evals.astype(jnp.complex64), evecs.astype(jnp.complex64)
-    return (evals, evecs)
+    evals, evecs = evals.astype(data.dtype), evecs.astype(data.dtype)
+    return evals, evecs
 
 def herm_no_vecs(data):
     evals = jnp.linalg.eigvalsh(data)
-    evals = evals.astype(jnp.complex64)
-    return (evals, None)
+    evals = evals.astype(data.dtype)
+    return evals, None
 
 def nonherm_no_vecs(data):
     evals = jnp.linalg.eigvals(data)
-    evals = evals.astype(jnp.complex64)
-    return (evals, None)
+    evals = evals.astype(data.dtype)
+    return evals, None
 
 
-@partial(jit, static_argnums=[2, 3, 4])
-def _eigs_jaxarray(data, isherm, vecs, eigvals, low_first):
+@partial(jit, static_argnums=[1, 2, 3, 4])
+def eigs_jaxarray(data, isherm=None, vecs=True, sort='low', eigvals=0):
     """
-    Internal function to dispatch the eigenvalue solver to `eigh`, `eig`,
-    `eigvalsh` or `eigvals` based on the parameters.
+    Return eigenvalues and eigenvectors for a `Data` of type `"jax"`. Takes no
+    special keyword arguments; see the primary documentation in :func:`.eigs`.
     """
+    N = data.shape[0]
+    if data.shape[0] != data.shape[1]:
+        raise TypeError("Can only diagonalize square matrices")
+    if sort not in ('low', 'high'):
+        raise ValueError("'sort' must be 'low' or 'high'")
+    if eigvals > N:
+        raise ValueError("Number of requested eigen vals/vecs must be <= N.")
+    eigvals = eigvals or N
+    low_first = {"low": True, "high": False}[sort]
+    isherm = isherm if isherm is not None else jnp.bool_(isherm_jaxarray(data))
+
     if vecs:
         evals, evecs = lax.cond(
             isherm, herm_with_vecs,
-            nonherm_with_vecs, data
+            nonherm_with_vecs, data._jxa
         )
     else:
         evals, evecs = lax.cond(
             isherm, herm_no_vecs,
-            nonherm_no_vecs, data
+            nonherm_no_vecs, data._jxa
         )
     
     perm = jnp.argsort(evals.real)
@@ -61,29 +72,6 @@ def _eigs_jaxarray(data, isherm, vecs, eigvals, low_first):
         if not low_first:
             evecs = evecs[:, ::-1]
         evecs = evecs[:, :eigvals]
-
-    return evals, evecs
-
-
-# Can't jit it if we accept isherm=None
-def eigs_jaxarray(data, isherm=None, vecs=True, sort='low', eigvals=0):
-    """
-    Return eigenvalues and eigenvectors for a `Data` of type `"jax"`.  Takes no
-    special keyword arguments; see the primary documentation in :func:`.eigs`.
-    """
-    N = data.shape[0]
-    if data.shape[0] != data.shape[1]:
-        raise TypeError("Can only diagonalize square matrices")
-    if sort not in ('low', 'high'):
-        raise ValueError("'sort' must be 'low' or 'high'")
-    if eigvals > N:
-        raise ValueError("Number of requested eigen vals/vecs must be <= N.")
-    eigvals = eigvals or N
-    # Let dict raise keyerror of
-    low_first = {"low": True, "high": False}[sort]
-    isherm = isherm if isherm is not None else jnp.bool(isherm_jaxarray(data))
-
-    evals, evecs = _eigs_jaxarray(data._jxa, isherm, vecs, eigvals, low_first)
 
     return (evals, JaxArray(evecs, copy=False)) if vecs else evals
 

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -20,16 +20,15 @@ def test_eigen_known_oper():
 
 
 @pytest.mark.parametrize(
-    ["rand"],
+    ["rand", "isherm"],
     [
-        pytest.param(qutip.rand_herm, id="hermitian"),
-        pytest.param(qutip.rand_unitary, id="non-hermitian"),
+        pytest.param(qutip.rand_herm, True, id="hermitian"),
+        pytest.param(qutip.rand_unitary, None, id="non-hermitian"),
     ],
 )
 @pytest.mark.parametrize("order", ["low", "high"])
-def test_eigen_rand_oper(rand, order):
+def test_eigen_rand_oper(rand, isherm, order):
     mat = rand(10, dtype="jax").data
-    isherm = rand is qutip.rand_herm
     kw = {"isherm": isherm, "sort": order}
     spvals, spvecs = qutip_jax.eigs_jaxarray(mat, vecs=True, **kw)
     sp_energies = qutip_jax.eigs_jaxarray(mat, vecs=False, **kw)
@@ -42,17 +41,16 @@ def test_eigen_rand_oper(rand, order):
 
 
 @pytest.mark.parametrize(
-    "rand",
+    ["rand", "isherm"],
     [
-        pytest.param(qutip.rand_herm, id="hermitian"),
-        pytest.param(qutip.rand_unitary, id="non-hermitian"),
+        pytest.param(qutip.rand_herm, True, id="hermitian"),
+        pytest.param(qutip.rand_unitary, None, id="non-hermitian"),
     ],
 )
 @pytest.mark.parametrize("order", ["low", "high"])
 @pytest.mark.parametrize("N", [1, 5, 8, 9])
-def test_eigvals_parameter(rand, order, N):
+def test_eigvals_parameter(rand, isherm, order, N):
     mat = rand(10, dtype="jax").data
-    isherm = rand is qutip.rand_herm
     kw = {"isherm": isherm, "sort": order}
     spvals, spvecs = qutip_jax.eigs_jaxarray(mat, vecs=True, eigvals=N, **kw)
     sp_energies = qutip_jax.eigs_jaxarray(mat, vecs=False, eigvals=N, **kw)


### PR DESCRIPTION
##Description
This PR is in an effort to enable jax.jit with qutip.core.metrics and entropy. It fixes _eigs_jaxarray to be compatible with jax.jit.

##Result
With this change trace_dist works with jax.jit

