### PR TITLE
Add dispatcher for sqrtm

### DIFF
--- a/src/qutip_jax/unary.py
+++ b/src/qutip_jax/unary.py
@@ -18,6 +18,7 @@ __all__ = [
     "conj_jaxdia",
     "inv_jaxarray",
     "expm_jaxarray",
+    "sqrtm_jaxarray",
     "project_jaxarray",
 ]
 
@@ -113,6 +114,12 @@ def inv_jaxarray(matrix):
     return JaxArray._fast_constructor(linalg.inv(matrix._jxa), matrix.shape)
 
 
+def sqrtm_jaxarray(matrix):
+    """Matrix square root `sqrt(A)` for a matrix `A`."""
+    _check_square_shape(matrix)
+    return JaxArray._fast_constructor(linalg.sqrtm(matrix._jxa), matrix.shape)
+
+
 @jit
 def _project_ket(array):
     return array @ array.T.conj()
@@ -182,6 +189,11 @@ qutip.data.inv.add_specialisations(
     [
         (JaxArray, JaxArray, inv_jaxarray),
     ]
+)
+
+
+qutip.data.sqrtm.add_specialisations(
+    [(JaxArray, JaxArray, sqrtm_jaxarray),]
 )
 
 

--- a/tests/test_unary.py
+++ b/tests/test_unary.py
@@ -70,7 +70,7 @@ class TestInv(testing.TestInv):
     specialisations = [pytest.param(_inv_jax, JaxArray, JaxArray)]
 
 
-class TestExpm(testing.TestExpm):
+class TestSqrtm(testing.TestExpm):
     specialisations = [
         pytest.param(qutip_jax.sqrtm_jaxarray, JaxArray, JaxArray)
     ]

--- a/tests/test_unary.py
+++ b/tests/test_unary.py
@@ -70,7 +70,7 @@ class TestInv(testing.TestInv):
     specialisations = [pytest.param(_inv_jax, JaxArray, JaxArray)]
 
 
-class TestSqrtm(testing.TestExpm):
+class TestSqrtm(testing.TestSqrtm):
     specialisations = [
         pytest.param(qutip_jax.sqrtm_jaxarray, JaxArray, JaxArray)
     ]

--- a/tests/test_unary.py
+++ b/tests/test_unary.py
@@ -70,6 +70,12 @@ class TestInv(testing.TestInv):
     specialisations = [pytest.param(_inv_jax, JaxArray, JaxArray)]
 
 
+class TestExpm(testing.TestExpm):
+    specialisations = [
+        pytest.param(qutip_jax.sqrtm_jaxarray, JaxArray, JaxArray)
+    ]
+
+
 class TestProject(testing.TestProject):
     specialisations = [
         pytest.param(qutip_jax.project_jaxarray, JaxArray, JaxArray)


### PR DESCRIPTION
**Description**
This PR aims to add dispatcher for `sqrtm` to `jax.jit` funtionality in `qutip.core.metrics`, a similar PR has also been in `qutip`

Note: `jax.grad` still does not work because there is no differentiation available in `jax.grad` for Schur decomposition