### PR TITLE
Update warnings filter for pytest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,12 +58,7 @@ jobs:
         # to see if something hung.
         timeout-minutes: 60
         run: |
-          pytest -Werror --durations=0 --durations-min=1.0 --verbosity=1 --color=yes \
-            -W ignore::UserWarning:qutip \
-            -W "ignore:Complex dtype:UserWarning" \
-            -W "ignore:jax.core.pp_eqn_rules is deprecated.:DeprecationWarning" \
-            -W "ignore:unhashable type:FutureWarning" \
-            -W "ignore:In a future release of JAX,:DeprecationWarning"
+          pytest --durations=0 --durations-min=1.0 --verbosity=1 --color=yes --cov=qutip_jax --cov-report=
           # Above flags are:
           #  --durations=0 --durations-min=1.0
           #     at the end, show a list of all the tests that took longer than a
@@ -78,16 +73,6 @@ jobs:
           #  --cov-report=
           #     don't print the coverage report to the terminal---it just adds
           #     cruft, and we're going to upload the .coverage file to Coveralls
-          #  -Werror
-          #     Unless explicitly ignored, warnings are errors.
-          #  -W ignore::UserWarning:qutip
-          #     Ignore matplotlib missing warnings
-          #  -W "ignore:Complex dtype:UserWarning"
-          #     Ignore diffrax's partial complex support
-          #  -W "ignore:jax.core.pp_eqn_rules is deprecated.:DeprecationWarning"
-          #  -W "ignore:unhashable type:FutureWarning"
-          #  -W "ignore:In a future release of JAX,:DeprecationWarning"
-          #     Diffrax / equinox are have warning with latest jax
           # These flags are added to those in pyproject.toml.
 
       - name: Upload to Coveralls

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,12 @@ jobs:
         # to see if something hung.
         timeout-minutes: 60
         run: |
-          pytest --durations=0 --durations-min=1.0 --verbosity=1 --cov=qutip_jax --cov-report= --color=yes -W ignore::UserWarning:qutip -W "ignore:Complex dtype:UserWarning"
+          pytest -Werror --durations=0 --durations-min=1.0 --verbosity=1 --color=yes \
+            -W ignore::UserWarning:qutip \
+            -W "ignore:Complex dtype:UserWarning" \
+            -W "ignore:jax.core.pp_eqn_rules is deprecated.:DeprecationWarning" \
+            -W "ignore:unhashable type:FutureWarning" \
+            -W "ignore:In a future release of JAX,:DeprecationWarning"
           # Above flags are:
           #  --durations=0 --durations-min=1.0
           #     at the end, show a list of all the tests that took longer than a
@@ -73,8 +78,16 @@ jobs:
           #  --cov-report=
           #     don't print the coverage report to the terminal---it just adds
           #     cruft, and we're going to upload the .coverage file to Coveralls
+          #  -Werror
+          #     Unless explicitly ignored, warnings are errors.
           #  -W ignore::UserWarning:qutip
           #     Ignore matplotlib missing warnings
+          #  -W "ignore:Complex dtype:UserWarning"
+          #     Ignore diffrax's partial complex support
+          #  -W "ignore:jax.core.pp_eqn_rules is deprecated.:DeprecationWarning"
+          #  -W "ignore:unhashable type:FutureWarning"
+          #  -W "ignore:In a future release of JAX,:DeprecationWarning"
+          #     Diffrax / equinox are have warning with latest jax
           # These flags are added to those in pyproject.toml.
 
       - name: Upload to Coveralls

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -66,12 +66,7 @@ jobs:
         # to see if something hung.
         timeout-minutes: 60
         run: |
-          pytest -Werror --durations=0 --durations-min=1.0 --verbosity=1 --color=yes \
-            -W ignore::UserWarning:qutip \
-            -W "ignore:Complex dtype:UserWarning" \
-            -W "ignore:jax.core.pp_eqn_rules is deprecated.:DeprecationWarning" \
-            -W "ignore:unhashable type:FutureWarning" \
-            -W "ignore:In a future release of JAX,:DeprecationWarning"
+          pytest -Werror --durations=0 --durations-min=1.0 --verbosity=1 --color=yes
           # Above flags are:
           #  --durations=0 --durations-min=1.0
           #     at the end, show a list of all the tests that took longer than a
@@ -79,20 +74,8 @@ jobs:
           #  --verbosity=1
           #     turn the verbosity up so pytest prints the names of the tests
           #     it's currently working on
-          #  --cov=qutip_jax
-          #     limit coverage reporting to code that's within the qutip_jax package
           #  --color=yes
           #     force coloured output in the terminal
-          #  -Werror
-          #     Unless explicitly ignored, warnings are errors.
-          #  -W ignore::UserWarning:qutip
-          #     Ignore matplotlib missing warnings
-          #  -W "ignore:Complex dtype:UserWarning"
-          #     Ignore diffrax's partial complex support
-          #  -W "ignore:jax.core.pp_eqn_rules is deprecated.:DeprecationWarning"
-          #  -W "ignore:unhashable type:FutureWarning"
-          #  -W "ignore:In a future release of JAX,:DeprecationWarning"
-          #     Diffrax / equinox are have warning with latest jax
           # These flags are added to those in pyproject.toml.
 
   finalise:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -66,7 +66,12 @@ jobs:
         # to see if something hung.
         timeout-minutes: 60
         run: |
-          pytest --durations=0 --durations-min=1.0 --verbosity=1 --color=yes -W ignore::UserWarning:qutip -W "ignore:Complex dtype:UserWarning"
+          pytest -Werror --durations=0 --durations-min=1.0 --verbosity=1 --color=yes \
+            -W ignore::UserWarning:qutip \
+            -W "ignore:Complex dtype:UserWarning" \
+            -W "ignore:jax.core.pp_eqn_rules is deprecated.:DeprecationWarning" \
+            -W "ignore:unhashable type:FutureWarning" \
+            -W "ignore:In a future release of JAX,:DeprecationWarning"
           # Above flags are:
           #  --durations=0 --durations-min=1.0
           #     at the end, show a list of all the tests that took longer than a
@@ -78,8 +83,16 @@ jobs:
           #     limit coverage reporting to code that's within the qutip_jax package
           #  --color=yes
           #     force coloured output in the terminal
+          #  -Werror
+          #     Unless explicitly ignored, warnings are errors.
           #  -W ignore::UserWarning:qutip
           #     Ignore matplotlib missing warnings
+          #  -W "ignore:Complex dtype:UserWarning"
+          #     Ignore diffrax's partial complex support
+          #  -W "ignore:jax.core.pp_eqn_rules is deprecated.:DeprecationWarning"
+          #  -W "ignore:unhashable type:FutureWarning"
+          #  -W "ignore:In a future release of JAX,:DeprecationWarning"
+          #     Diffrax / equinox are have warning with latest jax
           # These flags are added to those in pyproject.toml.
 
   finalise:

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -14,7 +14,7 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 readthedocs-sphinx-search==0.3.2
 numpydoc==1.4.0
-matplotlib==3.7.1
+matplotlib>=3.9.0
 docutils==0.18.1
 jax
 jax[cpu]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,3 @@ requires = [
     "wheel",
 ]
 build-backend = "setuptools.build_meta"
-
-[tool.pytest.ini_options]
-addopts = "--strict-config --strict-markers"
-testpaths = [
-    "tests",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
-addopts = "-Werror --strict-config --strict-markers -W \"ignore:Complex dtype:UserWarning\""
+addopts = "--strict-config --strict-markers"
 testpaths = [
     "tests",
 ]

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,12 @@
+[pytest]
+addopts = --strict-config --strict-markers
+filterwarnings =
+    error
+    ; Ignore matplotlib missing warnings
+    ignore:matplotlib not found:UserWarning
+    ; Ignore diffrax's partial complex support
+    ignore:Complex dtype:UserWarning
+    ; Diffrax / equinox are have warning with latest jax
+    ignore:jax.core.pp_eqn_rules is deprecated.:DeprecationWarning
+    ignore:unhashable type:FutureWarning
+    ignore:In a future release of JAX,:DeprecationWarning


### PR DESCRIPTION
Add filter for warnings raised by diffrax with latest jax.
Move the `-We` to tests instead of `pyproject.toml` for easier local tests.