### PR TITLE
Fix contradicting declaration

### DIFF
--- a/tests/test_qutip/test_mcsolve.py
+++ b/tests/test_qutip/test_mcsolve.py
@@ -10,7 +10,7 @@ from functools import partial
 qjax.set_as_default()
 
 # Define time-dependent functions
-@partial(jax.jit, static_argnames=("omega",))
+@jax.jit
 def H_1_coeff(t, omega):
     return 2.0 * jnp.pi * 0.25 * jnp.cos(2.0 * omega * t)
 


### PR DESCRIPTION
The args `omega` was declared as a static value (metadata, not tracked by jax) but we derived on it.
A new update made this contradiction raise an error.