### PR TITLE
Add verbose options to upload step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,8 @@ jobs:
 
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        verbose: true
 
   github-release:
     name: >-
@@ -117,3 +119,4 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: https://test.pypi.org/legacy/
+        verbose: true


### PR DESCRIPTION
The upload to testpypi failed, but the error is not clear.
Add verbose option to show why it failed.