### PR TITLE
Add missing attributes to Qobj tree representation

### DIFF
--- a/src/qutip_jax/qutip_trees.py
+++ b/src/qutip_jax/qutip_trees.py
@@ -7,7 +7,7 @@ __all__ = []
 
 
 _QOBJ_DEFAULT_STATE = {
-    attr: val
+    attr: None
     for attr, val in Qobj([[0]]).__dict__.items()
     if attr not in ("_data", "_dims")
 }

--- a/src/qutip_jax/qutip_trees.py
+++ b/src/qutip_jax/qutip_trees.py
@@ -6,20 +6,16 @@ from .qobjevo import JaxJitCoeff
 __all__ = []
 
 
+_QOBJ_DEFAULT_STATE = {
+    attr: val
+    for attr, val in Qobj([[0]]).__dict__.items()
+    if attr not in ("_data", "_dims")
+}
+
+
 def qobj_tree_flatten(qobj):
     children = (qobj.to("jax").data,)
-    aux_data = {"_dims": qobj._dims}
-    # TODO: find a better way to maintain attributes and their
-    # default values (~ Qobj's model)
-    _qobj_cache_attr = {
-            "_isherm": None,
-            "_isunitary": None,
-            "_ishp": None,
-            "_iscp": None,
-            "_istp": None,
-            "_iscptp": None,
-    }
-    aux_data |= _qobj_cache_attr
+    aux_data = {"_dims": qobj._dims, **_QOBJ_DEFAULT_STATE}
     return (children, aux_data)
 
 

--- a/src/qutip_jax/qutip_trees.py
+++ b/src/qutip_jax/qutip_trees.py
@@ -8,12 +8,18 @@ __all__ = []
 
 def qobj_tree_flatten(qobj):
     children = (qobj.to("jax").data,)
-    aux_data = {
-        "_dims": qobj._dims,
-        # Attribute that depend on the data are not safe to be set.
-        "_isherm": None,
-        "_isunitary": None,
+    aux_data = {"_dims": qobj._dims}
+    # TODO: find a better way to maintain attributes and their
+    # default values (~ Qobj's model)
+    _qobj_cache_attr = {
+            "_isherm": None,
+            "_isunitary": None,
+            "_ishp": None,
+            "_iscp": None,
+            "_istp": None,
+            "_iscptp": None,
     }
+    aux_data |= _qobj_cache_attr
     return (children, aux_data)
 
 


### PR DESCRIPTION
Solves an attribute error by extending attributes of Qobj, which qutip-jax knows about when building a tree representation. 
Context: PR 2886 in qutip introduced new private attributes for caching in Qobj. Because of this, some qutip-jax tests (namely, `tests/test_qutip/test_qobj.py`, on the attempt to copy a Qobj - [link](https://github.com/qutip/qutip/actions/runs/30324572363/job/90167135633)), failed with an attribute error. 